### PR TITLE
Add "continue" keyword.

### DIFF
--- a/Wren.YAML-tmLanguage
+++ b/Wren.YAML-tmLanguage
@@ -108,7 +108,7 @@ repository:
   keyword:
     patterns:
     - name: keyword.control.wren
-      match: \b(break|else|for|if|import|in|new|return|while|var)\b
+      match: \b(break|continue|else|for|if|import|in|new|return|while|var)\b
     - name: keyword.operator.logical.wren
       match: (!|&&|\|\|)
     - name: keyword.control.wren

--- a/Wren.tmLanguage
+++ b/Wren.tmLanguage
@@ -314,7 +314,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(break|else|for|if|import|in|new|return|while|var)\b</string>
+					<string>\b(break|continue|else|for|if|import|in|new|return|while|var)\b</string>
 					<key>name</key>
 					<string>keyword.control.wren</string>
 				</dict>


### PR DESCRIPTION
Add the missing "continue" keyword to the language definition files.